### PR TITLE
Fix for visual studio 2015 (140) importing of environment variables.

### DIFF
--- a/Src/Pscx/Modules/Utility/Pscx.Utility.psm1
+++ b/Src/Pscx/Modules/Utility/Pscx.Utility.psm1
@@ -2185,7 +2185,7 @@ function Import-VisualStudioVars
     param
     (
         [Parameter(Mandatory = $true, Position = 0)]
-        [ValidateSet('90', '2008', '100', '2010', '110', '2012', '120', '2013', '140')]
+        [ValidateSet('90', '2008', '100', '2010', '110', '2012', '120', '2013', '140', '2015')]
         [string]
         $VisualStudioVersion,
 
@@ -2216,6 +2216,11 @@ function Import-VisualStudioVars
             '120|2013' {
                 Push-EnvironmentBlock -Description "Before importing VS 2013 $Architecture environment variables"
                 Invoke-BatchFile "${env:VS120COMNTOOLS}..\..\VC\vcvarsall.bat" $Architecture
+            }
+            
+            '140|2015' {
+                Push-EnvironmentBlock -Description "Before importing VS 2015 $Architecture environment variables"
+                Invoke-BatchFile "${env:VS140COMNTOOLS}vsvars32.bat" $Architecture
             }
 
             default {


### PR DESCRIPTION
This is a super-minor change but I thought it would be good to include the environment variables for VS2015 - in particular since 'vcvarsall.bat' doesn't exist for it, but vsvars32.bat does.